### PR TITLE
#24 feat: 당일 판매량 순서대로 정렬 기능 구현

### DIFF
--- a/backend/src/main/java/team6/codesquad/kiosk/order/repository/MenuRepository.java
+++ b/backend/src/main/java/team6/codesquad/kiosk/order/repository/MenuRepository.java
@@ -109,14 +109,15 @@ public class MenuRepository {
 		return keys;
 	}
 
-	public void checkDailySales() {
+	public Boolean isExistDailySales() {
 		// 오늘 판매량이 존재하는지 확인하는 쿼리
 		String sql = "SELECT EXISTS(SELECT 1 FROM sales WHERE DATE_FORMAT(date, '%y-%m-%d') = DATE_FORMAT(?, '%y-%m-%d'))";
-		Boolean isExistDailySales = jdbcTemplate.queryForObject(sql, Boolean.class, LocalDateTime.now());
-		if (Boolean.FALSE.equals(isExistDailySales)) {
-			jdbcTemplate.query("select * from menu", menuRowMapper())
-				.forEach(menuResponseDto
-					-> createDailySales(menuResponseDto.getId()));  // 메뉴마다 당일판매량(sales)을 생성하는 쿼리를 날린다.
-		}
+		return jdbcTemplate.queryForObject(sql, Boolean.class, LocalDateTime.now());
+	}
+
+	public void fillCountZero() {
+		jdbcTemplate.query("select * from menu", menuRowMapper())
+			.forEach(menuResponseDto
+				-> createDailySales(menuResponseDto.getId()));  // 메뉴마다 당일판매량(sales)을 생성하는 쿼리를 날린다.
 	}
 }

--- a/backend/src/main/java/team6/codesquad/kiosk/order/repository/MenuRepository.java
+++ b/backend/src/main/java/team6/codesquad/kiosk/order/repository/MenuRepository.java
@@ -1,11 +1,19 @@
 package team6.codesquad.kiosk.order.repository;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import team6.codesquad.kiosk.order.dto.response.CategoryResponseDto;
@@ -17,6 +25,18 @@ public class MenuRepository {
 
 	public MenuRepository(DataSource dataSource) {
 		jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	public int createDailySales(int menuId) {
+		SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(jdbcTemplate);
+		jdbcInsert.withTableName("sales").usingGeneratedKeyColumns("id");
+		Map<String, Object> parameters = new ConcurrentHashMap<>();
+		parameters.put("count", 0);
+		parameters.put("date", LocalDateTime.now());
+		parameters.put("menu_id", menuId);
+
+		Number key = jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(parameters));
+		return key.intValue(); // sales 테이블의 id
 	}
 
 	private RowMapper<CategoryResponseDto> categoryRowMapper() {
@@ -44,11 +64,59 @@ public class MenuRepository {
 	}
 
 	public List<CategoryResponseDto> findAll() {
+		// sales 테이블에 count 값으로 정렬 된 menu들
 		return jdbcTemplate.query("select * from category", categoryRowMapper());
 	}
 
 	// TODO: Sales 테이블에서 오늘 날짜(date)에 해당하는 menu들을 모아서 count별로 정렬 후, 카테고리 별로 나눠 List에 담는다.
 	public List<MenuResponseDto> findAllMenuByCategoryId(int categoryId) {
-		return jdbcTemplate.query("select * from menu where category_id = ?", menuRowMapper(), categoryId);
+		List<MenuResponseDto> menuResponseDtos = jdbcTemplate.query("select * from menu where category_id = ?",
+			menuRowMapper(), categoryId);
+		List<Integer> menuIds = menuResponseDtos.stream().map(MenuResponseDto::getId).toList();
+		return getMenuByMenuId(menuResponseDtos, sortedMenuIdByCount(menuIds));
+	}
+
+	private List<MenuResponseDto> getMenuByMenuId(List<MenuResponseDto> menuResponseDtos, List<Integer> menuIds) {
+		List<MenuResponseDto> newMenuResponseDtos = new ArrayList<>();
+		for (Integer menuId : menuIds) {
+			MenuResponseDto menu = menuResponseDtos.stream()
+				.filter(menuResponseDto -> menuResponseDto.getId() == menuId)
+				.findFirst().get();
+			newMenuResponseDtos.add(menu);
+		}
+		return newMenuResponseDtos;
+	}
+
+	private List<Integer> sortedMenuIdByCount(List<Integer> menuIds) {
+		Map<Integer, Integer> map = new HashMap<>(); // (menuId, count)
+		menuIds.forEach(menuId -> { // sales 테이블에서 menuId로 count 값을 가져온다
+			String sql = "SELECT count FROM sales WHERE menu_id = ? AND DATE_FORMAT(?, '%y-%m-%d')";
+			int count = jdbcTemplate.queryForObject(sql, Integer.class, menuId, LocalDateTime.now());
+			map.put(menuId, count); // map에 넣는다.
+		});
+		return sortHashMapByValueDescending(map);
+	}
+
+	public List<Integer> sortHashMapByValueDescending(Map<Integer, Integer> map) {
+		List<Map.Entry<Integer, Integer>> entries = new ArrayList<>(map.entrySet());
+		entries.sort(Map.Entry.comparingByValue(Comparator.reverseOrder()));
+
+		List<Integer> keys = new ArrayList<>();
+		for (Map.Entry<Integer, Integer> entry : entries) {
+			keys.add(entry.getKey());
+		}
+
+		return keys;
+	}
+
+	public void checkDailySales() {
+		// 오늘 판매량이 존재하는지 확인하는 쿼리
+		String sql = "SELECT EXISTS(SELECT 1 FROM sales WHERE DATE_FORMAT(date, '%y-%m-%d') = DATE_FORMAT(?, '%y-%m-%d'))";
+		Boolean isExistDailySales = jdbcTemplate.queryForObject(sql, Boolean.class, LocalDateTime.now());
+		if (Boolean.FALSE.equals(isExistDailySales)) {
+			jdbcTemplate.query("select * from menu", menuRowMapper())
+				.forEach(menuResponseDto
+					-> createDailySales(menuResponseDto.getId()));  // 메뉴마다 당일판매량(sales)을 생성하는 쿼리를 날린다.
+		}
 	}
 }

--- a/backend/src/main/java/team6/codesquad/kiosk/order/service/MenuService.java
+++ b/backend/src/main/java/team6/codesquad/kiosk/order/service/MenuService.java
@@ -16,7 +16,9 @@ public class MenuService {
 	private final MenuRepository menuRepository;
 
 	public List<CategoryResponseDto> getCategories() {
-		menuRepository.checkDailySales();
+		if (!menuRepository.isExistDailySales()) {
+			menuRepository.fillCountZero();
+		}
 		return menuRepository.findAll();
 	}
 

--- a/backend/src/main/java/team6/codesquad/kiosk/order/service/MenuService.java
+++ b/backend/src/main/java/team6/codesquad/kiosk/order/service/MenuService.java
@@ -16,6 +16,7 @@ public class MenuService {
 	private final MenuRepository menuRepository;
 
 	public List<CategoryResponseDto> getCategories() {
+		menuRepository.checkDailySales();
 		return menuRepository.findAll();
 	}
 

--- a/backend/src/test/java/team6/codesquad/kiosk/menu/MenuRepositoryTest.java
+++ b/backend/src/test/java/team6/codesquad/kiosk/menu/MenuRepositoryTest.java
@@ -41,7 +41,7 @@ public class MenuRepositoryTest {
 	void findAll() {
 		menuRepository.findAll()
 			.forEach(categoryResponseDto -> {
-				assertThat(categoryResponseDto.getMenuResponseDtos()).isNotEmpty();
+				assertThat(categoryResponseDto.getMenus()).isNotEmpty();
 			});
 	}
 }


### PR DESCRIPTION
# 구현 과정
1. sales 테이블의 date에 오늘 날짜가 없으면 (앞으로 들어올 order가 첫 주문이 되므로) 
모든 메뉴에 대해 `count = 0`, `date = LocalDateTime.now()` 로 설정해서 행(row)을 추가한다.
2.  sales 테이블의 date에 오늘 날짜가 있으면 count를 기준으로 내림차순 정렬한 menu 리스트를 반환,
3. 반환한 menu 리스트를 해당 category에 담고, 모든 category를 리스트에 담아 반환한다.

# 수정한 기능
1. 당일 판매량 기능 메서드 분리 
- 당일 판매량 확인
- count를 0으로 하는 sales 테이블 추가

# 남은 할 일
테스트 코드 작성

# 확인 부탁
[schema.sql 및 data.sql 작성](https://gist.github.com/sudago/612e8c16b537e832e002a784c05bfbd2)
- order-status는 제거된 상태입니다.
- data.sql에 sales 테이블 데이터 추가되었습니다.
- 반환 값은 postman 으로 만든 [mock 서버](https://16afc0b1-b7ec-4aa0-bbc2-94a9d06696bc.mock.pstmn.io/) 에서 확인 할 수 있습니다.
